### PR TITLE
DEVOPS-4536 : Remove dependency to puppet-archive because of dependen…

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,6 @@ fixtures:
   forge_modules:
     stdlib:
       repo: "puppetlabs/stdlib"
-    archive:
-      repo: "puppet/archive"
-      ref: "1.3.0"
+    wget:
+      repo: "maestrodev/wget"
+      ref: "1.7.3"

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/Talend/puppet-cloudwatch",
   "issues_url": "https://github.com/Talend/puppet-cloudwatch/issues",
   "dependencies": [
-    {"name": "puppet/archive", "version_requirement": ">=1.0.0 < 2.0.0"},
+    {"name": "maestrodev/wget", "version_requirement": ">=1.0.0 <2.0.0"},
     {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.20.0 < 5.0.0"}
   ],
   "requirements": [

--- a/spec/classes/mongodb_exporter_spec.rb
+++ b/spec/classes/mongodb_exporter_spec.rb
@@ -9,7 +9,7 @@ describe 'monitoring::mongodb_exporter' do
       is_expected.to contain_user('mongodb_exporter')
       is_expected.to contain_file('/usr/lib/systemd/system/mongodb_exporter.service')
       is_expected.to contain_file('/etc/sysconfig/mongodb_exporter')
-      is_expected.to contain_archive('/tmp/mongodb_exporter-0.3.1.linux-amd64.tar.gz')
+      is_expected.to contain_wget__fetch('/tmp/mongodb_exporter-0.3.1.linux-amd64.tar.gz')
       is_expected.to contain_service('mongodb_exporter.service')
     }
   end

--- a/spec/classes/node_exporter_spec.rb
+++ b/spec/classes/node_exporter_spec.rb
@@ -9,7 +9,7 @@ describe 'monitoring::node_exporter' do
       is_expected.to contain_user('node_exporter')
       is_expected.to contain_file('/usr/lib/systemd/system/node_exporter.service')
       is_expected.to contain_file('/etc/sysconfig/node_exporter')
-      is_expected.to contain_archive('/tmp/node_exporter-0.15.2.linux-amd64.tar.gz')
+      is_expected.to contain_wget__fetch('/tmp/node_exporter-0.15.2.linux-amd64.tar.gz')
       is_expected.to contain_service('node_exporter.service')
     }
   end


### PR DESCRIPTION
Because we can't use it on tipaas-ops, and this module must be compatible with tipaasops and talend-cloud-installer