### PR TITLE
Fix mismatch pb when config file updated while service not restarted

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -70,6 +70,7 @@ define monitoring::daemon (
     owner   => $user,
     group   => $user,
     require => User[$user],
+    notify  => Service["${name}.service"],
   }
 
   file { $exporter_systemd_environement_file_path:
@@ -78,6 +79,7 @@ define monitoring::daemon (
     owner   => $user,
     group   => $user,
     require => User[$user],
+    notify  => Service["${name}.service"],
   }
 
   service { "${name}.service":


### PR DESCRIPTION
Change on config file should notify the service to restart. Otherwise the config change will not take effect automatically.