### PR TITLE
fix(CI): fix jenkins job build error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development do
 end
 
 group :system_tests do
+  gem 'artifactory', '2.8.2'
   gem 'mixlib-shellout', '2.2.7'
   gem 'kitchen-ec2', '1.3.2'
   gem 'kitchen-puppet', '3.3.1'


### PR DESCRIPTION
* Current 'artifactory' gem version is 3.0.0 requires Ruby 2.3
* Freeze 'artifactory' gem to a previously known working version (last successfull job)